### PR TITLE
Updated required golang version to 1.9

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ Client and server software to query DNS over HTTPS, using [Google DNS-over-HTTPS
 
 ## Easy start
 
-Install [Go](https://golang.org), at least version 1.8.
+Install [Go](https://golang.org), at least version 1.9.
 
 First create an empty directory, used for `$GOPATH`:
 


### PR DESCRIPTION
Golang 1.9 is required since the dial field in client.go:87 has been added in golang 1.9