### PR TITLE
Add client/server support for multiple listen addresses

### DIFF
--- a/doh-client/config.go
+++ b/doh-client/config.go
@@ -30,7 +30,7 @@ import (
 )
 
 type config struct {
-	Listen         string   `toml:"listen"`
+	Listen         []string `toml:"listen"`
 	UpstreamGoogle []string `toml:"upstream_google"`
 	UpstreamIETF   []string `toml:"upstream_ietf"`
 	Bootstrap      []string `toml:"bootstrap"`
@@ -50,8 +50,8 @@ func loadConfig(path string) (*config, error) {
 		return nil, &configError{fmt.Sprintf("unknown option %q", key.String())}
 	}
 
-	if conf.Listen == "" {
-		conf.Listen = "127.0.0.1:53"
+	if len(conf.Listen) == 0 {
+		conf.Listen = []string{"127.0.0.1:53"}
 	}
 	if len(conf.UpstreamGoogle) == 0 && len(conf.UpstreamIETF) == 0 {
 		conf.UpstreamGoogle = []string{"https://dns.google.com/resolve"}

--- a/doh-client/doh-client.conf
+++ b/doh-client/doh-client.conf
@@ -1,5 +1,7 @@
 # DNS listen port
-listen = "127.0.0.1:53"
+listen = [
+    "127.0.0.1:53"
+]
 
 # HTTP path for upstream resolver
 # If multiple servers are specified, a random one will be chosen each time.

--- a/doh-server/config.go
+++ b/doh-server/config.go
@@ -30,7 +30,7 @@ import (
 )
 
 type config struct {
-	Listen   string   `toml:"listen"`
+	Listen   []string `toml:"listen"`
 	Cert     string   `toml:"cert"`
 	Key      string   `toml:"key"`
 	Path     string   `toml:"path"`
@@ -51,9 +51,10 @@ func loadConfig(path string) (*config, error) {
 		return nil, &configError{fmt.Sprintf("unknown option %q", key.String())}
 	}
 
-	if conf.Listen == "" {
-		conf.Listen = "127.0.0.1:8053"
+	if len(conf.Listen) == 0 {
+		conf.Listen = []string{"127.0.0.1:8053"}
 	}
+
 	if conf.Path == "" {
 		conf.Path = "/dns-query"
 	}

--- a/doh-server/doh-server.conf
+++ b/doh-server/doh-server.conf
@@ -1,5 +1,7 @@
 # HTTP listen port
-listen = "127.0.0.1:8053"
+listen = [
+    "127.0.0.1:8053"
+]
 
 # TLS certification file
 cert = ""

--- a/doh-server/server.go
+++ b/doh-server/server.go
@@ -75,10 +75,27 @@ func (s *Server) Start() error {
 	if s.conf.Verbose {
 		servemux = handlers.CombinedLoggingHandler(os.Stdout, servemux)
 	}
-	if s.conf.Cert != "" || s.conf.Key != "" {
-		return http.ListenAndServeTLS(s.conf.Listen, s.conf.Cert, s.conf.Key, servemux)
+	listeners := make(chan error, len(s.conf.Listen))
+	for _, addr := range s.conf.Listen {
+		if s.conf.Cert != "" || s.conf.Key != "" {
+			go func() {
+				listeners <- http.ListenAndServeTLS(addr, s.conf.Cert, s.conf.Key, servemux)
+			}()
+			continue
+		}
+		go func() {
+			listeners <- http.ListenAndServe(addr, servemux)
+		}()
 	}
-	return http.ListenAndServe(s.conf.Listen, servemux)
+	// wait for all handlers
+	for i := 0; i < cap(listeners); i++ {
+		err := <-listeners
+		if err != nil {
+			return err
+		}
+	}
+	close(listeners)
+	return nil
 }
 
 func (s *Server) handlerFunc(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This PR adds support for multiple listen addresses, like other similar software allows to (dnsmasq, stubby, dnscrypt-proxy etc).

The only downside I can see is that it breaks the configuration for those who have it already installed.