### PR TITLE
Add an option to skip ipv6 DNS queries (AAAA) to reduce DNS calls

### DIFF
--- a/doh-server/config.go
+++ b/doh-server/config.go
@@ -34,10 +34,11 @@ type config struct {
 	Cert     string   `toml:"cert"`
 	Key      string   `toml:"key"`
 	Path     string   `toml:"path"`
-	Upstream []string `toml:"upstream"`
+	SkipIpv6 bool	  `toml:"skipipv6"`
 	Timeout  uint     `toml:"timeout"`
 	Tries    uint     `toml:"tries"`
 	TCPOnly  bool     `toml:"tcp_only"`
+	Upstream []string `toml:"upstream"`
 	Verbose  bool     `toml:"verbose"`
 }
 

--- a/doh-server/doh-server.conf
+++ b/doh-server/doh-server.conf
@@ -37,4 +37,7 @@ tries = 3
 tcp_only = false
 
 # Enable logging
-verbose = false
+verbose = true
+
+#SkipIPv6 query
+skipipv6 = true

--- a/doh-server/ietf.go
+++ b/doh-server/ietf.go
@@ -93,6 +93,14 @@ func (s *Server) parseRequestIETF(w http.ResponseWriter, r *http.Request) *DNSRe
 		} else {
 			questionType = strconv.Itoa(int(question.Qtype))
 		}
+		if s.conf.SkipIpv6 && questionType == "AAAA" {
+			fmt.Printf("Skippig type: %s \n", questionType)
+			return &DNSRequest{
+				errcode: 400,
+				errtext: "no IPv6",
+			}
+
+		}
 		fmt.Printf("%s - - [%s] \"%s %s %s\"\n", r.RemoteAddr, time.Now().Format("02/Jan/2006:15:04:05 -0700"), questionName, questionClass, questionType)
 	}
 

--- a/doh-server/server.go
+++ b/doh-server/server.go
@@ -70,6 +70,7 @@ func NewServer(conf *config) (s *Server) {
 		servemux: http.NewServeMux(),
 	}
 	s.servemux.HandleFunc(conf.Path, s.handlerFunc)
+	fmt.Printf("Listening on %s...\n", conf.Listen)
 	return
 }
 


### PR DESCRIPTION
Firefow set this parameter network.trr.early-AAAA to false.
This means for each normal name resolve, Firefox issues one HTTP request for A entries and another for AAAA entries. The responses come back separately and can come in any order. If the A records arrive first, Firefox will - as an optimization - continue and use those addresses without waiting for the second response.

So every dns call form Firefox becomes two queries for the upstream server and only one (the IPv4) will be used.

I created an option to silently drop the AAAA query and ask to the upstream server only the IPv4 resolution.
