### PR TITLE
Fix segfault when no_cookies=true

### DIFF
--- a/doh-client/client.go
+++ b/doh-client/client.go
@@ -114,7 +114,10 @@ func NewClient(conf *config) (c *Client, err error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		c.cookieJar = nil;
 	}
+
 	c.httpClientMux = new(sync.RWMutex)
 	err = c.newHTTPClient()
 	if err != nil {


### PR DESCRIPTION
Tried disabling cookies, got a SIGSEGV, wah wah. I would've assumed go initializes to null by default, but apparently not.