### PR TITLE
doh-server: change to google.go

### DIFF
--- a/doh-server/google.go
+++ b/doh-server/google.go
@@ -71,9 +71,9 @@ func (s *Server) parseRequestGoogle(w http.ResponseWriter, r *http.Request) *DNS
 
 	cdStr := r.FormValue("cd")
 	cd := false
-	if cdStr == "1" || strings.ToUpper(cdStr) == "TRUE" {
+	if cdStr == "1" || strings.EqualFold(cdStr, "true") {
 		cd = true
-	} else if cdStr == "0" || strings.ToUpper(cdStr) == "FALSE" || cdStr == "" {
+	} else if cdStr == "0" || strings.EqualFold(cdStr, "false") || cdStr == "" {
 	} else {
 		return &DNSRequest{
 			errcode: 400,

--- a/doh-server/google.go
+++ b/doh-server/google.go
@@ -71,9 +71,9 @@ func (s *Server) parseRequestGoogle(w http.ResponseWriter, r *http.Request) *DNS
 
 	cdStr := r.FormValue("cd")
 	cd := false
-	if cdStr == "1" || cdStr == "true" {
+	if cdStr == "1" || strings.ToUpper(cdStr) == "TRUE" {
 		cd = true
-	} else if cdStr == "0" || cdStr == "false" || cdStr == "" {
+	} else if cdStr == "0" || strings.ToUpper(cdStr) == "FALSE" || cdStr == "" {
 	} else {
 		return &DNSRequest{
 			errcode: 400,


### PR DESCRIPTION
Allow the "cd" parameter to be case insensitive to work with some clients that send True/False instead of true/false such as gDNS.