### PR TITLE
Replace switch case with map

### DIFF
--- a/doh-client/main.go
+++ b/doh-client/main.go
@@ -79,8 +79,13 @@ func main() {
 	// process tracking. But I understand some cloud service providers have
 	// their own monitoring system. So this feature is only enabled on Linux and
 	// BSD series platforms which lacks functionality similar to cgroup.
-	switch runtime.GOOS {
-	case "dragonfly", "freebsd", "linux", "netbsd", "openbsd":
+	if _, ok := map[string]struct{}{
+		"dragonfly": {},
+		"freebsd":   {},
+		"linux":     {},
+		"netbsd":    {},
+		"openbsd":   {},
+	}[runtime.GOOS]; ok {
 		pidFile = flag.String("pid-file", "", "PID file for legacy supervision systems lacking support for reliable cgroup-based process tracking")
 	}
 

--- a/doh-server/main.go
+++ b/doh-server/main.go
@@ -79,8 +79,13 @@ func main() {
 	// process tracking. But I understand some cloud service providers have
 	// their own monitoring system. So this feature is only enabled on Linux and
 	// BSD series platforms which lacks functionality similar to cgroup.
-	switch runtime.GOOS {
-	case "dragonfly", "freebsd", "linux", "netbsd", "openbsd":
+	if _, ok := map[string]struct{}{
+		"dragonfly": {},
+		"freebsd":   {},
+		"linux":     {},
+		"netbsd":    {},
+		"openbsd":   {},
+	}[runtime.GOOS]; ok {
 		pidFile = flag.String("pid-file", "", "PID file for legacy supervision systems lacking support for reliable cgroup-based process tracking")
 	}
 


### PR DESCRIPTION
Yes, use map can be fastest, but I found another reason why we should use map to replace switch case:

if we want to add or delete some scene, we can modify the  map clearly and easily
```go
map[string]struct{}{
		"dragonfly": {},
		"freebsd":   {},
		"linux":     {},
		"netbsd":    {},
		"openbsd":   {},
		"somethingNew": {},
}
```
