### PR TITLE
Add local_addr configuration for doh-server

### DIFF
--- a/doh-server/config.go
+++ b/doh-server/config.go
@@ -58,10 +58,6 @@ func loadConfig(path string) (*config, error) {
 		conf.Listen = []string{"127.0.0.1:8053", "[::1]:8053"}
 	}
 
-	if conf.LocalAddr == "" {
-		conf.LocalAddr = conf.Listen[0]
-	}
-
 	if conf.Path == "" {
 		conf.Path = "/dns-query"
 	}

--- a/doh-server/config.go
+++ b/doh-server/config.go
@@ -31,6 +31,7 @@ import (
 
 type config struct {
 	Listen           []string `toml:"listen"`
+	LocalAddr        string   `toml:"local_addr"`
 	Cert             string   `toml:"cert"`
 	Key              string   `toml:"key"`
 	Path             string   `toml:"path"`
@@ -55,6 +56,10 @@ func loadConfig(path string) (*config, error) {
 
 	if len(conf.Listen) == 0 {
 		conf.Listen = []string{"127.0.0.1:8053", "[::1]:8053"}
+	}
+
+	if conf.LocalAddr == "" {
+		conf.LocalAddr = conf.Listen[0]
 	}
 
 	if conf.Path == "" {

--- a/doh-server/doh-server.conf
+++ b/doh-server/doh-server.conf
@@ -4,7 +4,7 @@ listen = [
     "[::1]:8053",
 ]
 
-# HTTP local address for upstream DNS
+# Local address and port for upstream DNS
 # If left empty, a local address is automatically chosen.
 local_addr = ""
 

--- a/doh-server/doh-server.conf
+++ b/doh-server/doh-server.conf
@@ -5,7 +5,7 @@ listen = [
 ]
 
 # HTTP local address for upstream DNS
-# If left empty, the first listen address will be used.
+# If left empty, a local address is automatically chosen.
 local_addr = ""
 
 # TLS certification file

--- a/doh-server/doh-server.conf
+++ b/doh-server/doh-server.conf
@@ -4,6 +4,10 @@ listen = [
     "[::1]:8053",
 ]
 
+# HTTP local address for upstream DNS
+# If left empty, the first listen address will be used.
+local_addr = ""
+
 # TLS certification file
 # If left empty, plain-text HTTP will be used.
 # You are recommended to leave empty and to use a server load balancer (e.g.

--- a/doh-server/main.go
+++ b/doh-server/main.go
@@ -110,6 +110,9 @@ func main() {
 		conf.Verbose = true
 	}
 
-	server := NewServer(conf)
+	server, err := NewServer(conf)
+	if err != nil {
+		log.Fatalln(err)
+	}
 	_ = server.Start()
 }

--- a/doh-server/main.go
+++ b/doh-server/main.go
@@ -110,9 +110,6 @@ func main() {
 		conf.Verbose = true
 	}
 
-	server, err := NewServer(conf)
-	if err != nil {
-		log.Fatalln(err)
-	}
+	server := NewServer(conf)
 	_ = server.Start()
 }

--- a/doh-server/server.go
+++ b/doh-server/server.go
@@ -78,6 +78,8 @@ func NewServer(conf *config) (s *Server) {
 				Timeout:   timeout,
 				LocalAddr: udpLocalAddr,
 			}
+		} else {
+			log.Println(err)
 		}
 		tcpLocalAddr, err := net.ResolveTCPAddr("tcp", conf.LocalAddr)
 		if err == nil {
@@ -85,6 +87,8 @@ func NewServer(conf *config) (s *Server) {
 				Timeout:   timeout,
 				LocalAddr: tcpLocalAddr,
 			}
+		} else {
+			log.Println(err)
 		}
 	}
 	s.servemux.HandleFunc(conf.Path, s.handlerFunc)


### PR DESCRIPTION
This commit adds a `local_addr` string value to `doh-server.conf`, specifying the IP address and port from which outgoing calls to upstream DNS resolvers should originate. This value is set as the `udpClient`'s and `tcpClient`'s `Dialer.LocalAddr` when initializing a `NewServer`. If the value is left empty in `doh-server.conf`, it defaults to the first `listen` address (which in turn defaults to `"127.0.0.1:8053"`).

One use case for this would be if `doh-server` is proxying requests to a local DNS resolver (e.g. `unbound` or Pi-hole). Up to version 2.0.0, all DNS queries from `doh-server` are sent from `127.0.0.1` (even if the `listen` address is set to a different loopback IP address), making it hard to distinguish them from all other local DNS queries from the same machine in the query logs.