### PR TITLE
Make Makefile compatible with swift5 and older swift versions

### DIFF
--- a/darwin-wrapper/Makefile
+++ b/darwin-wrapper/Makefile
@@ -3,10 +3,17 @@
 SWIFTC = swiftc
 PREFIX = /usr/local
 
+SWIFTC_VERS = $(shell swiftc -version | grep -i swift | awk 'match($$0, /[0-9]/) {print substr($$0, RSTART, RLENGTH) }')
+
 all: doh-logger
+    $(info SWIFTC_VERS="$(SWIFTC_VERS)")
 
 doh-logger: doh-logger.swift
-	$(SWIFTC) -o $@ -O -static-stdlib $<
+    ifeq ($(SWIFTC_VERS), 5)
+	    $(SWIFTC) -o $@ -O $<
+    else
+	    $(SWIFTC) -o $@ -O -static-stdlib $<
+    endif
 
 clean:
 	rm -f doh-logger


### PR DESCRIPTION
This should fix macos build errors between swift 5 and older versions.