### PR TITLE
Update address for google's resolver

### DIFF
--- a/doh-client/doh-client.conf
+++ b/doh-client/doh-client.conf
@@ -18,9 +18,9 @@ upstream_selector = "random"
 
 # weight should in (0, 100], if upstream_selector is random, weight will be ignored
 
-## Google's productive resolver, good ECS, bad DNSSEC
-#[[upstream.upstream_google]]
-#    url = "https://dns.google.com/resolve"
+## Google's resolver, good ECS, good DNSSEC
+#[[upstream.upstream_ietf]]
+#    url = "https://dns.google/dns-query"
 #    weight = 50
 
 ## CloudFlare's resolver, bad ECS, good DNSSEC
@@ -46,11 +46,6 @@ upstream_selector = "random"
 ## ECS is disabled for privacy by design: https://www.quad9.net/faq/#What_is_EDNS_Client-Subnet
 #[[upstream.upstream_ietf]]
 #    url = "https://9.9.9.9/dns-query"
-#    weight = 50
-
-## Google's experimental resolver, good ECS, good DNSSEC
-#[[upstream.upstream_ietf]]
-#    url = "https://dns.google.com/experimental"
 #    weight = 50
 
 ## CloudFlare's resolver for Tor, available only with Tor


### PR DESCRIPTION
The new ietf endpoint is the only one in the documentation now:
https://developers.google.com/speed/public-dns/docs/doh/

Their blog post prefers the new address too:
https://security.googleblog.com/2019/06/google-public-dns-over-https-doh.html