### PR TITLE
Add support for DNS-over-TLS upstream resolvers

### DIFF
--- a/doh-server/doh-server.conf
+++ b/doh-server/doh-server.conf
@@ -27,11 +27,16 @@ path = "/dns-query"
 
 # Upstream DNS resolver
 # If multiple servers are specified, a random one will be chosen each time.
+# You can use "udp", "tcp" or "tcp-tls" for the type prefix.
+# For "udp", UDP will first be used, and switch to TCP when the server asks to
+# or the response is too large.
+# For "tcp", only TCP will be used.
+# For "tcp-tls", DNS-over-TLS (RFC 7858) will be used to secure the upstream connection.
 upstream = [
-    "1.1.1.1:53",
-    "1.0.0.1:53",
-    "8.8.8.8:53",
-    "8.8.4.4:53",
+    "udp:1.1.1.1:53",
+    "udp:1.0.0.1:53",
+    "udp:8.8.8.8:53",
+    "udp:8.8.4.4:53",
 ]
 
 # Upstream timeout
@@ -39,9 +44,6 @@ timeout = 10
 
 # Number of tries if upstream DNS fails
 tries = 3
-
-# Only use TCP for DNS query
-tcp_only = false
 
 # Enable logging
 verbose = false

--- a/doh-server/server.go
+++ b/doh-server/server.go
@@ -35,15 +35,16 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
-	"github.com/m13253/dns-over-https/json-dns"
+	jsonDNS "github.com/m13253/dns-over-https/json-dns"
 	"github.com/miekg/dns"
 )
 
 type Server struct {
-	conf      *config
-	udpClient *dns.Client
-	tcpClient *dns.Client
-	servemux  *http.ServeMux
+	conf         *config
+	udpClient    *dns.Client
+	tcpClient    *dns.Client
+	tcpClientTLS *dns.Client
+	servemux     *http.ServeMux
 }
 
 type DNSRequest struct {
@@ -69,6 +70,10 @@ func NewServer(conf *config) (*Server, error) {
 			Net:     "tcp",
 			Timeout: timeout,
 		},
+		tcpClientTLS: &dns.Client{
+			Net:     "tcp-tls",
+			Timeout: timeout,
+		},
 		servemux: http.NewServeMux(),
 	}
 	if conf.LocalAddr != "" {
@@ -85,6 +90,10 @@ func NewServer(conf *config) (*Server, error) {
 			LocalAddr: udpLocalAddr,
 		}
 		s.tcpClient.Dialer = &net.Dialer{
+			Timeout:   timeout,
+			LocalAddr: tcpLocalAddr,
+		}
+		s.tcpClientTLS.Dialer = &net.Dialer{
 			Timeout:   timeout,
 			LocalAddr: tcpLocalAddr,
 		}
@@ -279,23 +288,35 @@ func (s *Server) doDNSQuery(ctx context.Context, req *DNSRequest) (resp *DNSRequ
 	for i := uint(0); i < s.conf.Tries; i++ {
 		req.currentUpstream = s.conf.Upstream[rand.Intn(numServers)]
 
-		// Use TCP if always configured to or if the Query type dictates it (AXFR)
-		if s.conf.TCPOnly || (s.indexQuestionType(req.request, dns.TypeAXFR) > -1) {
-			req.response, _, err = s.tcpClient.Exchange(req.request, req.currentUpstream)
-		} else {
-			req.response, _, err = s.udpClient.Exchange(req.request, req.currentUpstream)
-			if err == nil && req.response != nil && req.response.Truncated {
-				log.Println(err)
-				req.response, _, err = s.tcpClient.Exchange(req.request, req.currentUpstream)
-			}
+		upstream, t := addressAndType(req.currentUpstream)
 
-			// Retry with TCP if this was an IXFR request and we only received an SOA
-			if (s.indexQuestionType(req.request, dns.TypeIXFR) > -1) &&
-				(len(req.response.Answer) == 1) &&
-				(req.response.Answer[0].Header().Rrtype == dns.TypeSOA) {
-				req.response, _, err = s.tcpClient.Exchange(req.request, req.currentUpstream)
+		switch t {
+		default:
+			log.Printf("invalid DNS type %q in upstream %q", t, upstream)
+			return nil, &configError{"invalid DNS type"}
+		// Use DNS-over-TLS (DoT) if configured to do so
+		case "tcp-tls":
+			req.response, _, err = s.tcpClientTLS.Exchange(req.request, upstream)
+		case "tcp", "udp":
+			// Use TCP if always configured to or if the Query type dictates it (AXFR)
+			if t == "tcp" || (s.indexQuestionType(req.request, dns.TypeAXFR) > -1) {
+				req.response, _, err = s.tcpClient.Exchange(req.request, upstream)
+			} else {
+				req.response, _, err = s.udpClient.Exchange(req.request, upstream)
+				if err == nil && req.response != nil && req.response.Truncated {
+					log.Println(err)
+					req.response, _, err = s.tcpClient.Exchange(req.request, upstream)
+				}
+
+				// Retry with TCP if this was an IXFR request and we only received an SOA
+				if (s.indexQuestionType(req.request, dns.TypeIXFR) > -1) &&
+					(len(req.response.Answer) == 1) &&
+					(req.response.Answer[0].Header().Rrtype == dns.TypeSOA) {
+					req.response, _, err = s.tcpClient.Exchange(req.request, upstream)
+				}
 			}
 		}
+
 		if err == nil {
 			return req, nil
 		}

--- a/json-dns/unmarshal.go
+++ b/json-dns/unmarshal.go
@@ -38,7 +38,7 @@ func PrepareReply(req *dns.Msg) *dns.Msg {
 	reply := new(dns.Msg)
 	reply.Id = req.Id
 	reply.Response = true
-	reply.Opcode = reply.Opcode
+	reply.Opcode = req.Opcode
 	reply.RecursionDesired = req.RecursionDesired
 	reply.RecursionAvailable = req.RecursionDesired
 	reply.CheckingDisabled = req.CheckingDisabled


### PR DESCRIPTION
~~This PR adds support for DNS-over-TLS (DoT) upstream resolvers.~~

~~It adds a new configuration option which affects declared resolvers globally:~~
```
# Only use DNS-over-TLS for upstream DNS queries
tls_only = false
```

A different approach, more invasive but which gives more flexibility, would be to get away from the global type booleans and instead support configuration declarations like:

```
# Upstream DNS resolver
# If multiple servers are specified, a random one will be chosen each time.
upstream = [
    "tcp:1.1.1.1:53",
    "tcp-tls:1.0.0.1:853",
    "udp:8.8.8.8:53",
]
```

Let me know if you prefer the latter instead, I could rewrite this patch.

Edit: rewritten the patch to use above approach.