### PR TITLE
Allow client opt-out of EDNS0 Client Subnet

### DIFF
--- a/doh-server/server.go
+++ b/doh-server/server.go
@@ -234,6 +234,11 @@ func (s *Server) handlerFunc(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) findClientIP(r *http.Request) net.IP {
+	noEcs := r.URL.Query().Get("no_ecs")
+	if strings.ToLower(noEcs) == "true" {
+		return nil
+	}
+
 	XForwardedFor := r.Header.Get("X-Forwarded-For")
 	if XForwardedFor != "" {
 		for _, addr := range strings.Split(XForwardedFor, ",") {


### PR DESCRIPTION
If the client have `no_ecs=true` in the query string, then ECS is disabled on-the-fly for this client. 