### PR TITLE
Added pi-hole as potential dnssec validator

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -15,7 +15,8 @@ ADD doh-client/doh-client.conf /doh-client.conf
 RUN sed -i '$!N;s/"127.0.0.1:53",.*"127.0.0.1:5380",/":53",/;P;D' /doh-client.conf
 RUN sed -i '$!N;s/"\[::1\]:53",.*"\[::1\]:5380",/":5380",/;P;D' /doh-client.conf
 
-EXPOSE 53
+EXPOSE 53/udp
+EXPOSE 53/tcp
 EXPOSE 5380
 
 ENTRYPOINT ["/doh-client"]

--- a/Readme.md
+++ b/Readme.md
@@ -303,7 +303,7 @@ services:
 DNS-over-HTTPS is compatible with DNSSEC, and requests DNSSEC signatures by
 default. However signature validation is not built-in. It is highly recommended
 that you install `unbound` or `bind` and pass results for them to validate DNS
-records.
+records. An instance of [Pi Hole](https://pi-hole.net) could also be used to validate DNS signatures as well as provide other capabilities.
 
 ## EDNS0-Client-Subnet (GeoDNS)
 


### PR DESCRIPTION
Proposed enhancement to Readme.md. Pi Hole can also provide DNSSEC validation. I have the doh-client running in docker using your dockerfile.client with pihole. Working well. I manage both via a docker-compose.yaml file.