### PR TITLE
Docker compose based doh-server setup example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -176,7 +176,7 @@ https://MY_SERVER_NAME {
   }
 }
 ```
-### Example configuration: Docker Compose + Traefik + Unbound
+### Example configuration: Docker Compose + Traefik + Unbound (Raspberry Pi/Linux/Mac) [linux/amd64,linux/arm64,linux/arm/v7]
 
 ```yaml
 version: '2.2'


### PR DESCRIPTION
1. Enhanced documentation
 - Formatting updates
 - Language names added for code blocks
2. Added full guide link for Docker based setup in Guides section
3. Changed example code of Docker Swarm to Docker Compose.
4. IPV6 Support: Added notes for IPV6 support.

Docker Compose + IPV6 support needs a custom configuration file and it deserves to be a separate section that will include Docker compose configuration, OS level and Docker daemon changes. This is still under testing on multiple arch types (linux/amd64,linux/arm64,linux/arm/v7). IPV6 based Docker Compose is going to be a whole new guide as there are a lot configurations to be done.