### PR TITLE
[JSON-DOH] Honor DNSSEC OK flag for incoming DNS requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.dll
 *.so
 *.dylib
+darwin-wrapper/doh-logger
+doh-client/doh-client
+doh-server/doh-server
 
 # Test binary, build with `go test -c`
 *.test

--- a/doh-client/google.go
+++ b/doh-client/google.go
@@ -67,6 +67,9 @@ func (c *Client) generateRequestGoogle(ctx context.Context, w dns.ResponseWriter
 	udpSize := uint16(512)
 	if opt := r.IsEdns0(); opt != nil {
 		udpSize = opt.UDPSize()
+		if opt.Do() {
+			requestURL += "&do=1"
+		}
 	}
 
 	ednsClientAddress, ednsClientNetmask := c.findClientIP(w, r)


### PR DESCRIPTION
`doh-client/doh-client.conf`
```diff
diff --git a/doh-client/doh-client.conf b/doh-client/doh-client.conf
index b6eff00..b709830 100644
--- a/doh-client/doh-client.conf
+++ b/doh-client/doh-client.conf
@@ -1,9 +1,6 @@
 # DNS listen port
 listen = [
-    "127.0.0.1:53",
-    "127.0.0.1:5380",
-    "[::1]:53",
-    "[::1]:5380",
+    "127.0.0.1:1053",
 
     ## To listen on both 0.0.0.0:53 and [::]:53, use the following line
     # ":53",
@@ -25,8 +22,8 @@ upstream_selector = "random"
 
 ## CloudFlare's resolver, bad ECS, good DNSSEC
 ## ECS is disabled for privacy by design: https://developers.cloudflare.com/1.1.1.1/nitty-gritty-details/#edns-client-subnet
-[[upstream.upstream_ietf]]
-    url = "https://cloudflare-dns.com/dns-query"
+[[upstream.upstream_google]]
+    url = "https://dns.google/resolve"
     weight = 50
 
 ## CloudFlare's resolver, bad ECS, good DNSSEC
@@ -131,4 +128,4 @@ no_ipv6 = false
 no_user_agent = false
 
 # Enable logging
-verbose = false
+verbose = true
```

According to https://developers.google.com/speed/public-dns/docs/doh/json
> **do**
> boolean, default: `false`
>
> The DO (DNSSEC OK) flag. Use `do=1`, or `do=true` to include DNSSEC records (RRSIG, NSEC, NSEC3); use `do=0`, `do=false`, or no `do` parameter to omit DNSSEC records.

`doh-client/doh-client` omits the DNSSEC OK flag even if we explicitly turned on `DO` flag.

Before:
```
$ dig @127.0.0.1 -p1053 +dnssec cloudflare.com

; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p1053 +dnssec cloudflare.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 29229
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;cloudflare.com.   IN A

;; ANSWER SECTION:
cloudflare.com.  199 IN A 104.17.175.85
cloudflare.com.  199 IN A 104.17.176.85

;; Query time: 61 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1)
;; WHEN: Sun Apr 19 10:53:33 CST 2020
;; MSG SIZE  rcvd: 75
```

After
```
$ dig @127.0.0.1 -p1053 +dnssec cloudflare.com

; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p1053 +dnssec cloudflare.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 12929
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;cloudflare.com.   IN A

;; ANSWER SECTION:
cloudflare.com.  164 IN A 104.17.176.85
cloudflare.com.  164 IN A 104.17.175.85
cloudflare.com.  164 IN RRSIG A 13 2 300 20200420035157 20200418015157 34505 cloudflare.com. DrikAQEU/O01AYhF4uz0iUVYHPXBO0oRL9dGosliV6pHI9EJ5d+qOQA9 Hs2Yoho0rRrnNhP29/KTg5D0Fgf8Jg==

;; Query time: 455 msec
;; SERVER: 127.0.0.1#1053(127.0.0.1)
;; WHEN: Sun Apr 19 10:54:10 CST 2020
;; MSG SIZE  rcvd: 185
```

see:
https://docs.menandmice.com/display/MM/How+to+test+DNSSEC+validation
https://www.cyberciti.biz/faq/unix-linux-test-and-validate-dnssec-using-dig-command-line/