### PR TITLE
Separate doh googel api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ doh-server/doh-server
 .glide/
 
 .idea/
+vendor/*

--- a/doh-server/config.go
+++ b/doh-server/config.go
@@ -36,6 +36,7 @@ type config struct {
 	Cert             string   `toml:"cert"`
 	Key              string   `toml:"key"`
 	Path             string   `toml:"path"`
+	JsonPath         string   `toml:"json_path"`
 	Upstream         []string `toml:"upstream"`
 	Timeout          uint     `toml:"timeout"`
 	Tries            uint     `toml:"tries"`
@@ -60,6 +61,9 @@ func loadConfig(path string) (*config, error) {
 
 	if conf.Path == "" {
 		conf.Path = "/dns-query"
+	}
+	if conf.JsonPath == "" {
+		conf.JsonPath = "/resolve"
 	}
 	if len(conf.Upstream) == 0 {
 		conf.Upstream = []string{"udp:8.8.8.8:53", "udp:8.8.4.4:53"}

--- a/doh-server/ietf.go
+++ b/doh-server/ietf.go
@@ -36,26 +36,43 @@ import (
 	"strings"
 	"time"
 
-	jsonDNS "github.com/m13253/dns-over-https/json-dns"
+	"github.com/m13253/dns-over-https/json-dns"
 	"github.com/miekg/dns"
 )
 
-func (s *Server) parseRequestIETF(ctx context.Context, w http.ResponseWriter, r *http.Request) *DNSRequest {
+func (s *Server) parsePostRequestIETF(ctx context.Context, w http.ResponseWriter, r *http.Request) *DNSRequest {
+	requestBinary, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return &DNSRequest{
+			errcode: 400,
+			errtext: fmt.Sprintf("Failed to read request body (%s)", err.Error()),
+		}
+	}
+
+	if len(requestBinary) == 0 {
+		return &DNSRequest{
+			errcode: 400,
+			errtext: fmt.Sprintf("Invalid argument value: \"dns\""),
+		}
+	}
+
+	if s.patchDNSCryptProxyReqID(w, r, requestBinary) {
+		return &DNSRequest{
+			errcode: 444,
+		}
+	}
+
+	return s.unpackDnsMsg(requestBinary, r)
+
+}
+
+func (s *Server) parseGetRequestIETF(ctx context.Context, w http.ResponseWriter, r *http.Request) *DNSRequest {
 	requestBase64 := r.FormValue("dns")
 	requestBinary, err := base64.RawURLEncoding.DecodeString(requestBase64)
 	if err != nil {
 		return &DNSRequest{
 			errcode: 400,
 			errtext: fmt.Sprintf("Invalid argument value: \"dns\" = %q", requestBase64),
-		}
-	}
-	if len(requestBinary) == 0 && (r.Header.Get("Content-Type") == "application/dns-message" || r.Header.Get("Content-Type") == "application/dns-udpwireformat") {
-		requestBinary, err = ioutil.ReadAll(r.Body)
-		if err != nil {
-			return &DNSRequest{
-				errcode: 400,
-				errtext: fmt.Sprintf("Failed to read request body (%s)", err.Error()),
-			}
 		}
 	}
 	if len(requestBinary) == 0 {
@@ -71,8 +88,75 @@ func (s *Server) parseRequestIETF(ctx context.Context, w http.ResponseWriter, r 
 		}
 	}
 
+	return s.unpackDnsMsg(requestBinary, r)
+}
+
+func (s *Server) generateResponseIETF(ctx context.Context, w http.ResponseWriter, r *http.Request, req *DNSRequest) {
+	respJSON := jsonDNS.Marshal(req.response)
+	req.response.Id = req.transactionID
+	respBytes, err := req.response.Pack()
+	if err != nil {
+		log.Printf("DNS packet construct failure with upstream %s: %v\n", req.currentUpstream, err)
+		jsonDNS.FormatError(w, fmt.Sprintf("DNS packet construct failure (%s)", err.Error()), 500)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/dns-message")
+	now := time.Now().UTC().Format(http.TimeFormat)
+	w.Header().Set("Date", now)
+	w.Header().Set("Last-Modified", now)
+	w.Header().Set("Vary", "Accept")
+
+	_ = s.patchFirefoxContentType(w, r, req)
+
+	if respJSON.HaveTTL {
+		if req.isTailored {
+			w.Header().Set("Cache-Control", "private, max-age="+strconv.FormatUint(uint64(respJSON.LeastTTL), 10))
+		} else {
+			w.Header().Set("Cache-Control", "public, max-age="+strconv.FormatUint(uint64(respJSON.LeastTTL), 10))
+		}
+		w.Header().Set("Expires", respJSON.EarliestExpires.Format(http.TimeFormat))
+	}
+
+	if respJSON.Status == dns.RcodeServerFailure {
+		log.Printf("received server failure from upstream %s: %v\n", req.currentUpstream, req.response)
+		w.WriteHeader(503)
+	}
+	_, err = w.Write(respBytes)
+	if err != nil {
+		log.Printf("failed to write to client: %v\n", err)
+	}
+}
+
+// Workaround a bug causing DNSCrypt-Proxy to expect a response with TransactionID = 0xcafe
+func (s *Server) patchDNSCryptProxyReqID(w http.ResponseWriter, r *http.Request, requestBinary []byte) bool {
+	if strings.Contains(r.UserAgent(), "dnscrypt-proxy") && bytes.Equal(requestBinary, []byte("\xca\xfe\x01\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00\x00\x02\x00\x01\x00\x00\x29\x10\x00\x00\x00\x80\x00\x00\x00")) {
+		log.Println("DNSCrypt-Proxy detected. Patching response.")
+		w.Header().Set("Content-Type", "application/dns-message")
+		w.Header().Set("Vary", "Accept, User-Agent")
+		now := time.Now().UTC().Format(http.TimeFormat)
+		w.Header().Set("Date", now)
+		w.Write([]byte("\xca\xfe\x81\x05\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x02\x00\x01\x00\x00\x10\x00\x01\x00\x00\x00\x00\x00\xa8\xa7\r\nWorkaround a bug causing DNSCrypt-Proxy to expect a response with TransactionID = 0xcafe\r\nRefer to https://github.com/jedisct1/dnscrypt-proxy/issues/526 for details."))
+		return true
+	}
+	return false
+}
+
+// Workaround a bug causing Firefox 61-62 to reject responses with Content-Type = application/dns-message
+func (s *Server) patchFirefoxContentType(w http.ResponseWriter, r *http.Request, req *DNSRequest) bool {
+	if strings.Contains(r.UserAgent(), "Firefox") && strings.Contains(r.Header.Get("Accept"), "application/dns-udpwireformat") && !strings.Contains(r.Header.Get("Accept"), "application/dns-message") {
+		log.Println("Firefox 61-62 detected. Patching response.")
+		w.Header().Set("Content-Type", "application/dns-udpwireformat")
+		w.Header().Set("Vary", "Accept, User-Agent")
+		req.isTailored = true
+		return true
+	}
+	return false
+}
+
+func (s *Server) unpackDnsMsg(requestBinary []byte, r *http.Request) *DNSRequest {
 	msg := new(dns.Msg)
-	err = msg.Unpack(requestBinary)
+	err := msg.Unpack(requestBinary)
 	if err != nil {
 		return &DNSRequest{
 			errcode: 400,
@@ -153,67 +237,5 @@ func (s *Server) parseRequestIETF(ctx context.Context, w http.ResponseWriter, r 
 		transactionID: transactionID,
 		isTailored:    isTailored,
 	}
-}
 
-func (s *Server) generateResponseIETF(ctx context.Context, w http.ResponseWriter, r *http.Request, req *DNSRequest) {
-	respJSON := jsonDNS.Marshal(req.response)
-	req.response.Id = req.transactionID
-	respBytes, err := req.response.Pack()
-	if err != nil {
-		log.Printf("DNS packet construct failure with upstream %s: %v\n", req.currentUpstream, err)
-		jsonDNS.FormatError(w, fmt.Sprintf("DNS packet construct failure (%s)", err.Error()), 500)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/dns-message")
-	now := time.Now().UTC().Format(http.TimeFormat)
-	w.Header().Set("Date", now)
-	w.Header().Set("Last-Modified", now)
-	w.Header().Set("Vary", "Accept")
-
-	_ = s.patchFirefoxContentType(w, r, req)
-
-	if respJSON.HaveTTL {
-		if req.isTailored {
-			w.Header().Set("Cache-Control", "private, max-age="+strconv.FormatUint(uint64(respJSON.LeastTTL), 10))
-		} else {
-			w.Header().Set("Cache-Control", "public, max-age="+strconv.FormatUint(uint64(respJSON.LeastTTL), 10))
-		}
-		w.Header().Set("Expires", respJSON.EarliestExpires.Format(http.TimeFormat))
-	}
-
-	if respJSON.Status == dns.RcodeServerFailure {
-		log.Printf("received server failure from upstream %s: %v\n", req.currentUpstream, req.response)
-		w.WriteHeader(503)
-	}
-	_, err = w.Write(respBytes)
-	if err != nil {
-		log.Printf("failed to write to client: %v\n", err)
-	}
-}
-
-// Workaround a bug causing DNSCrypt-Proxy to expect a response with TransactionID = 0xcafe
-func (s *Server) patchDNSCryptProxyReqID(w http.ResponseWriter, r *http.Request, requestBinary []byte) bool {
-	if strings.Contains(r.UserAgent(), "dnscrypt-proxy") && bytes.Equal(requestBinary, []byte("\xca\xfe\x01\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00\x00\x02\x00\x01\x00\x00\x29\x10\x00\x00\x00\x80\x00\x00\x00")) {
-		log.Println("DNSCrypt-Proxy detected. Patching response.")
-		w.Header().Set("Content-Type", "application/dns-message")
-		w.Header().Set("Vary", "Accept, User-Agent")
-		now := time.Now().UTC().Format(http.TimeFormat)
-		w.Header().Set("Date", now)
-		w.Write([]byte("\xca\xfe\x81\x05\x00\x01\x00\x01\x00\x00\x00\x00\x00\x00\x02\x00\x01\x00\x00\x10\x00\x01\x00\x00\x00\x00\x00\xa8\xa7\r\nWorkaround a bug causing DNSCrypt-Proxy to expect a response with TransactionID = 0xcafe\r\nRefer to https://github.com/jedisct1/dnscrypt-proxy/issues/526 for details."))
-		return true
-	}
-	return false
-}
-
-// Workaround a bug causing Firefox 61-62 to reject responses with Content-Type = application/dns-message
-func (s *Server) patchFirefoxContentType(w http.ResponseWriter, r *http.Request, req *DNSRequest) bool {
-	if strings.Contains(r.UserAgent(), "Firefox") && strings.Contains(r.Header.Get("Accept"), "application/dns-udpwireformat") && !strings.Contains(r.Header.Get("Accept"), "application/dns-message") {
-		log.Println("Firefox 61-62 detected. Patching response.")
-		w.Header().Set("Content-Type", "application/dns-udpwireformat")
-		w.Header().Set("Vary", "Accept, User-Agent")
-		req.isTailored = true
-		return true
-	}
-	return false
 }

--- a/doh-server/server.go
+++ b/doh-server/server.go
@@ -138,7 +138,7 @@ func (s *Server) handlerFunc(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS, POST")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Max-Age", "3600")
 	w.Header().Set("Server", USER_AGENT)
@@ -189,7 +189,7 @@ func (s *Server) handlerJsonFunc(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS, POST")
+	w.Header().Set("Access-Control-Allow-Methods", "GET")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Max-Age", "3600")
 	w.Header().Set("Server", USER_AGENT)


### PR DESCRIPTION
_Google Public DNS provides two distinct DoH APIs at these endpoints: 
https://dns.google/dns-query – RFC 8484 (GET and POST)
https://dns.google/resolve? – JSON API (GET)
from [https://developers.google.com/speed/public-dns/docs/doh]_

Make some changes according to the document.
