### PR TITLE
Fix an inconsistency in the example doh-client.conf

### DIFF
--- a/doh-client/doh-client.conf
+++ b/doh-client/doh-client.conf
@@ -64,7 +64,7 @@ upstream_selector = "random"
 # bootstrap server, please make this list empty.
 bootstrap = [
 
-    # Google's resolver, bad ECS, good DNSSEC
+    # Google's resolver, good ECS, good DNSSEC
     "8.8.8.8:53",
     "8.8.4.4:53",
 


### PR DESCRIPTION
Above, it was said that 8.8.8.8 had good ECS, so don't contradict that further down.

This confused a reviewer of https://github.com/NixOS/nixpkgs/pull/104530 :)