### PR TITLE
Add GitHub actions to build master and each PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,37 @@
+name: Go build for Linux
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.12
+      id: go
+
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Linux build
+      run: |
+        make
+
+    - name: Upload Linux build
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-amd64
+        path: |
+          doh-client/doh-client
+          doh-server/doh-server
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        # A directory to store and save the cache
+        path: ~/go/pkg/mod
+        # An explicit key for restoring and saving the cache
+        key: ${{ runner.os }}-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.12
+        go-version: 1.13
       id: go
 
     - name: Check out repository

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,11 @@
-.PHONY: all clean install uninstall deps
+.PHONY: all clean install uninstall
 
 PREFIX = /usr/local
 
 ifeq ($(GOROOT),)
 GOBUILD = go build
-GOGET = go get -d -v
-GOGET_UPDATE = go get -d -u -v
 else
 GOBUILD = $(GOROOT)/bin/go build
-GOGET = $(GOROOT)/bin/go get -d -v
-GOGET_UPDATE = $(GOROOT)/bin/go get -d -u -v
 endif
 
 ifeq ($(shell uname),Darwin)
@@ -57,14 +53,8 @@ uninstall:
 		$(MAKE) -C launchd uninstall "DESTDIR=$(DESTDIR)"; \
 	fi
 
-deps:
-	@# I am not sure if it is the correct way to keep the common library updated
-	$(GOGET_UPDATE) github.com/m13253/dns-over-https/doh-client/config
-	$(GOGET_UPDATE) github.com/m13253/dns-over-https/json-dns
-	$(GOGET) ./doh-client ./doh-server
-
-doh-client/doh-client: deps doh-client/client.go doh-client/config/config.go doh-client/google.go doh-client/ietf.go doh-client/main.go doh-client/version.go json-dns/error.go json-dns/globalip.go json-dns/marshal.go json-dns/response.go json-dns/unmarshal.go
+doh-client/doh-client: doh-client/client.go doh-client/config/config.go doh-client/google.go doh-client/ietf.go doh-client/main.go doh-client/version.go json-dns/error.go json-dns/globalip.go json-dns/marshal.go json-dns/response.go json-dns/unmarshal.go
 	cd doh-client && $(GOBUILD)
 
-doh-server/doh-server: deps doh-server/config.go doh-server/google.go doh-server/ietf.go doh-server/main.go doh-server/server.go doh-server/version.go json-dns/error.go json-dns/globalip.go json-dns/marshal.go json-dns/response.go json-dns/unmarshal.go
+doh-server/doh-server: doh-server/config.go doh-server/google.go doh-server/ietf.go doh-server/main.go doh-server/server.go doh-server/version.go json-dns/error.go json-dns/globalip.go json-dns/marshal.go json-dns/response.go json-dns/unmarshal.go
 	cd doh-server && $(GOBUILD)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m13253/dns-over-https
 
-go 1.12
+go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
Add GitHub actions to build master and each PR.

I did not see a Makefile target to build for Windows, so I did not add the stanzas for that.

There are also no integration tests otherwise they could be added as well.

This PR additionally moves from Go 1.12 to Go 1.13 because of the modules support, which allows to not have a `deps` target anymore, since Go does that automatically. Build was failing without upgrading to Go 1.13