### PR TITLE
Update go.yml to use ubuntu-latest for runs-on

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
Updated workflow to use ubuntu-latest as ubuntu-18.04 has been deprecated.