### PR TITLE
Pre-bump doh-client to next version 2.3.6

### DIFF
--- a/doh-client/version.go
+++ b/doh-client/version.go
@@ -24,6 +24,6 @@
 package main
 
 const (
-	VERSION    = "2.3.4"
+	VERSION    = "2.3.6"
 	USER_AGENT = "DNS-over-HTTPS/" + VERSION + " (+https://github.com/m13253/dns-over-https)"
 )


### PR DESCRIPTION
Pre-bump doh-client to next version 2.3.6
Ref: https://github.com/m13253/dns-over-https/commit/057797fed39d00577110cb0fcbea3f61dcabdd61#commitcomment-139691775