### PR TITLE
When systemd service fail to start, use an exponential backoff delay to restart it

### DIFF
--- a/systemd/doh-client.service
+++ b/systemd/doh-client.service
@@ -10,7 +10,10 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/usr/local/bin/doh-client -conf /etc/dns-over-https/doh-client.conf
 LimitNOFILE=1048576
 Restart=always
-RestartSec=3
+RestartSec=1s
+RestartMaxDelaySec=76s
+RestartSteps=9
+StartLimitIntervalSec=0
 Type=simple
 DynamicUser=yes
 

--- a/systemd/doh-server.service
+++ b/systemd/doh-server.service
@@ -8,7 +8,10 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/usr/local/bin/doh-server -conf /etc/dns-over-https/doh-server.conf
 LimitNOFILE=1048576
 Restart=always
-RestartSec=3
+RestartSec=1s
+RestartMaxDelaySec=76s
+RestartSteps=9
+StartLimitIntervalSec=0
 Type=simple
 DynamicUser=yes
 


### PR DESCRIPTION
This solves an issue that on (at least) Fedora and if NetworkManager starts too slow, systemd may stop trying to start it after hitting `StartLimitBurst` limit.

Thanks to systemd 254, by providing [`RestartSteps` and `RestartMaxDelaySec` options](https://www.man7.org/linux/man-pages/man5/systemd.service.5.html), we can let the service retry at an exponential backoff delay.

I choose the exponential factor to be 1.618, maxed at 76 seconds, because Fibonacci backoff seems to be another popular backoff sequence. By my educated guess, I think this should be a good number to start with?

I am not sure if this change would ruin somewhere else. Please cast your opinions before I merge it to the master branch.