### PR TITLE
config: Add captive portal domains

### DIFF
--- a/doh-client/doh-client.conf
+++ b/doh-client/doh-client.conf
@@ -83,6 +83,8 @@ passthrough = [
     "detectportal.firefox.com",
     "msftconnecttest.com",
     "nmcheck.gnome.org",
+    "globalreachtech.com",
+    "network-auth.com",
 
     "pool.ntp.org",
     "time.apple.com",


### PR DESCRIPTION
I recently connected to a public wifi point where the Firefox detect portal redirected me through to these domains, and I had to add them to my config to access the portal. If this is intended behavior feel free to close.